### PR TITLE
Update minimum Go version requirement from 1.21 to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Each repository is published to NATS as a JSON message:
 
 ### Prerequisites
 
-- Go 1.21+
+- Go 1.24+
 - Docker
 - NATS server (for testing)
 


### PR DESCRIPTION
## Summary
- Updated Go version requirement in README.md from 1.21+ to 1.24+

## Test plan
- [x] Verify documentation reflects correct Go version requirement
- [x] Confirm build process works with Go 1.24+